### PR TITLE
AME-8421 Fix ScopeValidator implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) 2013-2014 ForgeRock AS. All Rights Reserved
+   Copyright (c) 2013-2016 ForgeRock AS. All Rights Reserved
 
    The contents of this file are subject to the terms
    of the Common Development and Distribution License
@@ -24,7 +24,8 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.forgerock.openam.examples</groupId>
@@ -33,7 +34,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <openam.version>12.0.0-SNAPSHOT</openam.version>
+        <openam.version>13.0.0-SNAPSHOT</openam.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/org/forgerock/openam/examples/DeprecatedCustomScope.java
+++ b/src/main/java/org/forgerock/openam/examples/DeprecatedCustomScope.java
@@ -1,7 +1,7 @@
 /**
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2012-2014 ForgeRock AS. All Rights Reserved
+ * Copyright (c) 2012-2016 ForgeRock AS. All Rights Reserved
  *
  * The contents of this file are subject to the terms
  * of the Common Development and Distribution License
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.forgerock.oauth2.core.UserInfoClaims;
 import org.forgerock.openam.oauth2.legacy.CoreToken;
 import org.forgerock.openam.oauth2.provider.Scope;
 
@@ -87,10 +88,10 @@ public class DeprecatedCustomScope implements Scope {
     }
 
     @Override
-    public Map<String, Object> getUserInfo(CoreToken token) {
+    public UserInfoClaims getUserInfo(CoreToken token) {
         Map<String, Object> response = mapScopes(token);
         response.put("sub", token.getUserID());
-        return response;
+        return new UserInfoClaims(response, null);
     }
 
     @Override


### PR DESCRIPTION
This patch aligns the ScopeValidator impl. with OpenAM 13.

Seems to work for me with a relatively recent build:

    curl \
     --request POST \
     --data
"grant_type=client_credentials&username=demo&password=changeit\
    &client_id=myClientID&client_secret=password&scope=read" \
     http://openam.example.com:8088/openam/oauth2/access_token

{"access_token":"0ea1ae5a-2d6f-4722-9940-beb2be85d34c","scope":"read","t
oken_type":"Bearer","expires_in":3599}

    curl http://openam.example.com:8088/openam/oauth2/tokeninfo\
    ?access_token=0ea1ae5a-2d6f-4722-9940-beb2be85d34c

{"access_token":"0ea1ae5a-2d6f-4722-9940-beb2be85d34c","read":true,"gran
t_type":"client_credentials","scope":["read"],"realm":"/","token_type":"
Bearer","expires_in":3572,"write":false}